### PR TITLE
test: 💍 diff exists executed_dirs and module, same time

### DIFF
--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -28,6 +28,10 @@ func Test_getDirs(t *testing.T) {
 			[]string{"../testdata/terraform/modules/module_1/main.tf"},
 			[]string{"../testdata/terraform/environments/test_1/", "../testdata/terraform/environments/test_2/"},
 		},
+		"executed_dirsの差分とmoduleの差分の混在": {
+			[]string{"../testdata/terraform/environments/test_1/main.tf","../testdata/terraform/modules/module_1/main.tf"},
+			[]string{"../testdata/terraform/environments/test_1/"},
+		},
 	}
 
 	for name, a := range aa {


### PR DESCRIPTION
## 概要

- environments配下とmoduleの両方で変更があったときに、うまくtarget_dirが取れない？

```shell
❯ pbpaste
terraform/environments/prd/aws/backend/main.tf
terraform/environments/prd/aws/backend/outputs.tf
terraform/environments/stg/aws/backend/main.tf
terraform/environments/stg/aws/backend/outputs.tf
terraform/modules/aws/service/backend/ecs_scheduled_task.tf
terraform/modules/aws/service/backend/lambda_notification.tf
terraform/modules/aws/service/backend/outputs.tf
terraform/modules/aws/service/backend/variables.tf
❯ pbpaste |head -4 | tfdir get --config ./.tfdir/pull_request/staging.yaml
terraform/environments/prd/aws/backend/
terraform/environments/stg/aws/backend/
❯ pbpaste |tail -4 | tfdir get --config ./.tfdir/pull_request/staging.yaml
terraform/environments/prd/aws/backend
terraform/environments/stg/aws/backend
```
