### PR TITLE
ci: 🎡 release without tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,25 +1,39 @@
 ---
-name: release
+name: Release Drafter
+
 on:
-  push:
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+  pull_request:
+    types:
+      - closed
+    branches:
+      - master
 
 jobs:
   release:
     timeout-minutes: 3
-    name: Release Go Binary
-    runs-on: ubuntu-latest
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'release')  }}
     permissions:
-      contents: read
+      contents: write
+      pull-requests: read
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - name: generate tag
+        id: gen_tag
+        run: |
+          tag=$(TZ=Asia/Tokyo date +%Y%m%d%H%M%S)
+          echo "tag: $tag"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+      - name: push tag
+        run: |
+          git tag ${{ steps.gen_tag.outputs.tag }}
+          git push origin ${{ steps.gen_tag.outputs.tag }}
+
+      - uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348 # v6
         with:
-          aqua_version: v2.30.0
-      - uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
-        with:
-          version: latest
-          args: release --rm-dist
+          publish: true
+          tag: ${{ steps.gen_tag.outputs.tag }}
+          version: ${{ steps.gen_tag.outputs.tag }}
+          name: ${{ steps.gen_tag.outputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Linked issue

close 

## Description

- git tagしてgit pushして、ってreleaseがめんどくさい...
  - releaseラベルがついたPRをマージしたらreleaseが作られるようにする
