### PR TITLE
fix: 🐛 --rm-dist is deprecated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,6 @@ jobs:
           git push origin ${{ steps.gen_tag.outputs.tag }}
       - uses: goreleaser/goreleaser-action@v4
         with:
-          args: release --rm-dist
+          args: release  --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Linked issue

close 

## Description

- goreleaserの--rm-distオプションはdeprecated
  - --cleanを使う
